### PR TITLE
add method for duplicating slices `duplicateSliceByScorehash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ apiClient.moveSliceToFolder({
 })
 ```
 
+#### `duplicateSliceByScorehash(scorehash)`
+
+- Duplicates the slice with the scorehash `scorehash`.
+- Soundslice documentation: ["Duplicate slice"](https://www.soundslice.com/help/data-api/#duplicateslice)
+
+```javascript
+apiClient.duplicateSliceByScorehash('C1FVc')
+```
+
 #### `getSliceRecordingsBySlug(slug)`
 
 - Gets data about all recordings in the slice with slug `slug`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,5 @@
 # TODO
 
-Duplicate slice
-- `duplicateSliceByScorehash`
-- https://www.soundslice.com/help/data-api/#duplicateslice
-- HTTP POST
-- No parameters
-
 Delete recording
 - `deleteRecordingByRecordingId`
 - https://www.soundslice.com/help/data-api/#deleterecording

--- a/examples/duplicate-slice-by-scorehash.js
+++ b/examples/duplicate-slice-by-scorehash.js
@@ -1,3 +1,5 @@
+// $ node examples/duplicate-slice-by-scorehash.js
+
 const { apiClient } = require(`./index.js`);
 
 const scorehash = `5Kzcc`;
@@ -6,6 +8,7 @@ const main = async () => {
   try {
     const res = await apiClient.duplicateSliceByScorehash(scorehash);
 
+    // { scorehash: 'abcde', slug: '123456', url: '/slices/abcde/' }
     console.log(res.data);
   } catch (err) {
     console.error(`ERROR:`);

--- a/examples/duplicate-slice-by-scorehash.js
+++ b/examples/duplicate-slice-by-scorehash.js
@@ -1,0 +1,26 @@
+const { apiClient } = require(`./index.js`);
+
+const scorehash = `5Kzcc`;
+
+const main = async () => {
+  try {
+    const res = await apiClient.duplicateSliceByScorehash(scorehash);
+
+    console.log(res.data);
+  } catch (err) {
+    console.error(`ERROR:`);
+
+    const { data, status, statusText } = err.response;
+
+    // { status: 422, statusText: 'Unprocessable Entity' }
+    console.log({
+      status,
+      statusText,
+    });
+
+    // { error: 'Your account may not set the slug.' }
+    console.log(data);
+  }
+};
+
+main();

--- a/index.js
+++ b/index.js
@@ -55,6 +55,9 @@ module.exports = ({ SOUNDSLICE_APPLICATION_ID, SOUNDSLICE_PASSWORD }) => {
 
   const axiosInstance = axios.create({ baseURL, headers });
 
+  const duplicateSliceByScorehash = (scorehash) =>
+    axiosInstance.post(`/slices/${scorehash}/duplicate/`);
+
   const deleteSliceBySlug = (slug) => axiosInstance.delete(`/scores/${slug}/`);
 
   const { get } = axiosInstance;
@@ -72,6 +75,7 @@ module.exports = ({ SOUNDSLICE_APPLICATION_ID, SOUNDSLICE_PASSWORD }) => {
   return {
     createSlice,
     deleteSliceBySlug,
+    duplicateSliceByScorehash,
     getSliceBySlug,
     getSliceNotationBySlug,
     getSliceRecordingsBySlug,

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,9 +86,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -476,12 +476,12 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -650,9 +650,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
-      "integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
+      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -808,12 +808,12 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
@@ -1429,6 +1429,15 @@
         "yargs-unparser": "1.6.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1984,9 +1993,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
-    "eslint": "^7.8.1",
+    "eslint": "^7.9.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",
     "mocha": "^8.1.3"


### PR DESCRIPTION
I've added a new method to the API client, `duplicateSliceByScorehash`.  However, I'm marking this `WIP:` while I research this error message.

```sh
 $ node examples/duplicate-slice-by-scorehash.js

ERROR:

{ status: 422, statusText: 'Unprocessable Entity' }

{ error: 'Your account may not set the slug.' }
```