### PR TITLE
feat(deleteFolderByFolderId): add the ability to delete folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 **2020-09-27**
+- Published `v0.9.0`
+- Added `deleteFolderByFolderId`,
 - Published `v0.8.0`
 - Added `deleteRecordingByRecordingId`
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ apiClient.deleteRecordingByRecordingId('123456')
 apiClient.getSyncpointsByRecordingId('123456')
 ```
 
+#### `deleteFolderByFolderId(folderId)`
+
+- Deletes the given folder within your account’s slice manager.
+- The folder must be empty. It can’t contain any slices or other folders.
+- Soundslice documentation: ["Delete folder"](https://www.soundslice.com/help/data-api/#deletefolder)
+
+```javascript
+apiClient.deleteFolderByFolderId('12345')
+```
+
 #### `listFolders()`
 
 - Lists **top-level** folders within your account’s slice manager.

--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,3 @@ Rename folder
 - `renameFolder`
 - https://www.soundslice.com/help/data-api/#renamefolder
 - HTTP POST
-
-Delete folder
-- `deleteFolder`
-- https://www.soundslice.com/help/data-api/#deletefolder
-- HTTP DELETE

--- a/examples/delete-folder-by-folder-id.js
+++ b/examples/delete-folder-by-folder-id.js
@@ -1,0 +1,35 @@
+// deleteFolderByFolderId(folderId)
+
+const { apiClient } = require(`./index.js`);
+
+// change this to the ID of a recording you own & wish to delete
+// https://www.soundslice.com/help/data-api/#deletefolder
+const folderId = `21086`;
+
+const main = async () => {
+  try {
+    const res = await apiClient.deleteFolderByFolderId(folderId);
+
+    const { data, status } = res;
+
+    // 200
+    console.log(status);
+
+    // The ID of the deleted folder’s parent folder,
+    // or `null` if the deleted folder was in the root.
+    // { parent_id: 12345 }
+    console.log(data);
+  } catch (err) {
+    console.error(`ERROR:`);
+
+    const { status, statusText } = err.response;
+
+    // { status: 403, statusText: 'Forbidden' }
+    console.log({
+      status,
+      statusText,
+    });
+  }
+};
+
+main();

--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ module.exports = ({ SOUNDSLICE_APPLICATION_ID, SOUNDSLICE_PASSWORD }) => {
   const duplicateSliceByScorehash = (scorehash) =>
     axiosInstance.post(`/slices/${scorehash}/duplicate/`);
 
+  const deleteFolderByFolderId = (folderId) =>
+    axiosInstance.delete(`/folders/${folderId}/`);
   const deleteRecordingByRecordingId = (recordingId) =>
     axiosInstance.delete(`/recordings/${recordingId}/`);
   const deleteSliceBySlug = (slug) => axiosInstance.delete(`/scores/${slug}/`);
@@ -76,6 +78,7 @@ module.exports = ({ SOUNDSLICE_APPLICATION_ID, SOUNDSLICE_PASSWORD }) => {
 
   return {
     createSlice,
+    deleteFolderByFolderId,
     deleteRecordingByRecordingId,
     deleteSliceBySlug,
     duplicateSliceByScorehash,

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -16,6 +16,7 @@ describe(`soundslice-data-api`, () => {
 
       const expected = [
         `createSlice`,
+        `deleteFolderByFolderId`,
         `deleteRecordingByRecordingId`,
         `deleteSliceBySlug`,
         `duplicateSliceByScorehash`,
@@ -36,6 +37,12 @@ describe(`soundslice-data-api`, () => {
   describe(`createSlice`, () => {
     it(`should be a function`, () => {
       expect(apiClient.createSlice).to.be.a(`function`);
+    });
+  });
+
+  describe(`deleteFolderByFolderId`, () => {
+    it(`should be a function`, () => {
+      expect(apiClient.deleteFolderByFolderId).to.be.a(`function`);
     });
   });
 


### PR DESCRIPTION
This PR adds the method `deleteFolderByFolderId(folderId)` to the API client.

https://www.soundslice.com/help/data-api/#deletefolder