### PR TITLE
feat(renameFolder): add an `apiClient` method for renaming folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,21 @@ apiClient.createFolder({
 })
 ```
 
+#### `renameFolder()`
+
+- Renames a folder.
+- Soundslice documentation: ["Rename folder"](https://www.soundslice.com/help/data-api/#renamefolder)
+
+```javascript
+apiClient.renameFolder({
+  // Required - The folder's ID.
+  folderId: '12345',
+
+  // Required - The new name of the folder.
+  name: 'Renamed Folder',
+})
+```
+
 #### `deleteFolderByFolderId(folderId)`
 
 - Deletes the given folder within your account’s slice manager.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-# TODO
-
-Rename folder
-- `renameFolder`
-- https://www.soundslice.com/help/data-api/#renamefolder
-- HTTP POST

--- a/examples/rename-folder.js
+++ b/examples/rename-folder.js
@@ -1,0 +1,36 @@
+const { apiClient } = require(`./index.js`);
+
+const main = async () => {
+  const params = {
+    // Required - The folder's ID.
+    folderId: `12345`,
+
+    // Required - The new name of the folder.
+    name: `This folder has been renamed`,
+  };
+
+  let res;
+
+  try {
+    res = await apiClient.renameFolder(params);
+  } catch (err) {
+    console.error(`ERROR:`);
+
+    const { data, status, statusText } = err.response;
+
+    console.log({
+      status,
+      statusText,
+    });
+
+    console.log(data);
+
+    return;
+  }
+
+  console.log(res.data);
+
+  console.log(`https://www.soundslice.com/manage/folder-${res.data.id}/`);
+};
+
+main();

--- a/index.js
+++ b/index.js
@@ -54,6 +54,16 @@ module.exports = ({ SOUNDSLICE_APPLICATION_ID, SOUNDSLICE_PASSWORD }) => {
     return post(`${baseURL}/scores/${slug}/move/`, paramsObjClone);
   };
 
+  const renameFolder = (paramsObj) => {
+    const { folderId } = paramsObj;
+    const paramsObjClone = { ...paramsObj };
+
+    delete paramsObjClone.folderId;
+
+    // required: name
+    return post(`${baseURL}/folders/${folderId}/`, paramsObjClone);
+  };
+
   const axiosInstance = axios.create({ baseURL, headers });
 
   const duplicateSliceByScorehash = (scorehash) =>
@@ -92,5 +102,6 @@ module.exports = ({ SOUNDSLICE_APPLICATION_ID, SOUNDSLICE_PASSWORD }) => {
     listSlices,
     listSubfoldersByParentId,
     moveSliceToFolder,
+    renameFolder,
   };
 };

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -29,6 +29,7 @@ describe(`soundslice-data-api`, () => {
         `listSlices`,
         `listSubfoldersByParentId`,
         `moveSliceToFolder`,
+        `renameFolder`,
       ];
 
       expect(actual).to.eql(expected);
@@ -116,6 +117,12 @@ describe(`soundslice-data-api`, () => {
   describe(`moveSliceToFolder`, () => {
     it(`should be a function`, () => {
       expect(apiClient.moveSliceToFolder).to.be.a(`function`);
+    });
+  });
+
+  describe(`renameFolder`, () => {
+    it(`should be a function`, () => {
+      expect(apiClient.renameFolder).to.be.a(`function`);
     });
   });
 });


### PR DESCRIPTION
This PR adds the method `renameFolder`, which can be used to rename a folder.

Soundslice documentation: https://www.soundslice.com/help/data-api/#renamefolder

```javascript
res = await apiClient.renameFolder({
  // Required - The folder's ID.
  folderId: '12345',

  // Required - The new name of the folder.
  name: 'Renamed Folder',
})