### PR TITLE
0.18.0: `changeRecording` & `reorderSliceRecordings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,29 @@ apiClient.getSliceRecordingsByScorehash('HD8Nc')
 apiClient.getSliceRecordingsBySlug('123456')
 ```
 
+#### `changeRecording(paramsObj)`
+
+- Changes data for the recording with ID `recordingId`.
+- It's possible change a recording's `name`, and/or `source_data`, and/or `hls_url`.
+- Makes a POST request with the given parameters.
+- Other than `recordingId`, all params are optional.
+- If you don’t want to change a particular value, simply don't send its key with the request.
+- Soundslice documentation: ["Change recording"](https://www.soundslice.com/help/data-api/#changerecording)
+
+```javascript
+apiClient.changeRecording({
+    // Required
+  recordingId: 123456,
+
+  // the attribute of the recording that we'd like to change
+  name: `Changed Recording Name`,
+
+  // optionally, 'source_data' can be changed if `source` is 3 or 8
+
+  // optionally ,'hls_url' can be changed if `source` is 3
+})
+```
+
 #### `deleteRecordingByRecordingId(recordingId)`
 
 - Deletes the recording with the given `recordingId`, including all its associated data such as syncpoints and uploaded audio.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,30 @@ apiClient.getSliceRecordingsByScorehash('HD8Nc')
 apiClient.getSliceRecordingsBySlug('123456')
 ```
 
+#### `reorderSliceRecordings(paramsObj)`
+
+- Reorder a slice's recordings.
+- Sets the order of the recordings in the slice with a given `scorehash`.
+- Soundslice documentation: ["Reorder slice’s recordings"](https://www.soundslice.com/help/data-api/#reorderrecordings)
+
+```javascript
+apiClient.reorderSliceRecordings({
+  // The slice whose recordings you'd like to reorder.
+  scorehash: 'abcde',
+
+  // An array of recording IDs in your requested order.
+  // **OR** a string of recording IDs separated by commas.
+  //
+  // The first recording ID is the top-most recording in the Soundslice UI, and so forth.
+  // The last recording ID is the default.
+  // Every recording in the slice must be included in this data.
+  order: [222226, 222227, 222225],
+
+  // Optionally, pass a comma-delimited string:
+  // order: '222226,222227,222225'
+})
+```
+
 #### `changeRecording(paramsObj)`
 
 - Changes data for the recording with ID `recordingId`.
@@ -206,15 +230,15 @@ apiClient.getSliceRecordingsBySlug('123456')
 
 ```javascript
 apiClient.changeRecording({
-    // Required
+  // Required
   recordingId: 123456,
 
-  // the attribute of the recording that we'd like to change
-  name: `Changed Recording Name`,
+  // The attribute of the recording that you'd like to change.
+  name: 'Changed Recording Name',
 
-  // optionally, 'source_data' can be changed if `source` is 3 or 8
+  // Optionally, 'source_data' can be changed if `source` is 3 or 8.
 
-  // optionally ,'hls_url' can be changed if `source` is 3
+  // Optionally, 'hls_url' can be changed if `source` is 3.
 })
 ```
 

--- a/examples/change-recording.js
+++ b/examples/change-recording.js
@@ -1,0 +1,19 @@
+// examples/change-recording.js
+
+// https://www.soundslice.com/help/data-api/#changerecording
+
+const { apiClient, handleError, handleSuccess } = require(`./index.js`);
+
+const paramsObj = {
+  // the attribute of the recording that we'd like to change
+  name: `Changed Recording Name`,
+
+  // optionally, 'source_data' can be changed if `source` is 3 or 8
+
+  // optionally ,'hls_url' can be changed if `source` is 3
+
+  // required
+  recordingId: 123456,
+};
+
+apiClient.changeRecording(paramsObj).then(handleSuccess).catch(handleError);

--- a/examples/reorder-slice-recordings.js
+++ b/examples/reorder-slice-recordings.js
@@ -1,0 +1,15 @@
+// examples/reorder-slice-recordings.js
+
+// https://www.soundslice.com/help/data-api/#reorderrecordings
+
+const { apiClient, handleError, handleSuccess } = require(`./index.js`);
+
+const paramsObj = {
+  order: [222226, 222227, 222225],
+  scorehash: `abcde`,
+};
+
+apiClient
+  .reorderSliceRecordings(paramsObj)
+  .then(handleSuccess)
+  .catch(handleError);

--- a/src/get-api-client-instance.ts
+++ b/src/get-api-client-instance.ts
@@ -247,6 +247,44 @@ const getApiClientInstance = ({
     );
   };
 
+  /**
+   * - Changes data for the recording with ID `recordingId`.
+   * - It's possible change a recording's `name`, and/or `source_data`, and/or `hls_url`.
+   * - Makes a POST request with the given parameters.
+   * - Other than `recordingId`, all params are optional.
+   * - If you don’t want to change a particular value, simply don't send its key with the request.
+   * @see https://www.soundslice.com/help/data-api/#changerecording
+   *
+   * @param {Object} paramsObj paramsObj
+   * paramsObj.recordingId (Required) part of the URL we'll POST to
+   *
+   * paramsObj.name        (Optional) The name of the recording. Limit 100 characters.
+   * paramsObj.source_data (Optional) Extra data, depending on the value of `source`.
+   * paramsObj.hls_url     (Optional) The URL for an HLS playlist for this recording,
+   *                                  if `source` is 3.
+   *
+   * @return {Promise} an Axios promise
+   */
+  const changeRecording = (paramsObj: {
+    recordingId: number | string;
+    name?: string;
+    source_data?: string;
+    hls_url?: string;
+  }) => {
+    const paramsObjToPOST: Record<string, unknown> = { ...paramsObj };
+
+    // `recordingId` must be included in `paramsObj`
+    // because it's part of the URL we'll POST to
+    //
+    // however, we don't want to send it in the payload
+    delete paramsObjToPOST.recordingId;
+
+    return postWithFormData(
+      `/recordings/${paramsObj.recordingId}/`,
+      paramsObjToPOST,
+    );
+  };
+
   // all DELETE methods...
   const deleteFolderByFolderId = (folderId: number | string) =>
     axiosWrapper.delete(`/folders/${folderId}/`);
@@ -330,6 +368,7 @@ const getApiClientInstance = ({
     axiosWrapper.get(`/folders/?parent_id=${parentId}`);
 
   return {
+    changeRecording,
     createFolder,
     createRecording,
     createSlice,

--- a/src/get-api-client-instance.ts
+++ b/src/get-api-client-instance.ts
@@ -285,6 +285,35 @@ const getApiClientInstance = ({
     );
   };
 
+  /**
+   * - Reorder a slice's recordings.
+   * - Sets the order of the recordings in the slice with a given `scorehash`.
+   * @see https://www.soundslice.com/help/data-api/#reorderrecordings
+   *
+   * @param {Object} paramsObj paramsObj
+   * paramsObj.scorehash (Required) The slice whose recordings you'd like to reorder.
+   * paramsObj.order     (Required) An array of recording IDs in your requested order.
+   *                     **OR** a string of recording IDs separated by commas.
+   *
+   * @return {Promise} an Axios promise
+   */
+  const reorderSliceRecordings = (paramsObj: {
+    scorehash: number | string;
+    order: string | string[] | number[];
+  }) => {
+    const { order, scorehash } = paramsObj;
+
+    // if the caller has supplied an array of recording IDs,
+    // convert that to the format expected by Soundslice
+    const orderedRecordingIdsCSV = Array.isArray(order)
+      ? order.join(`,`)
+      : order;
+
+    return postWithFormData(`/slices/${scorehash}/recordings/order/`, {
+      order: orderedRecordingIdsCSV,
+    });
+  };
+
   // all DELETE methods...
   const deleteFolderByFolderId = (folderId: number | string) =>
     axiosWrapper.delete(`/folders/${folderId}/`);
@@ -401,6 +430,7 @@ const getApiClientInstance = ({
     moveSliceToFolder,
     putRecordingSyncpoints,
     renameFolder,
+    reorderSliceRecordings,
     uploadFile,
   };
 };

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -15,6 +15,7 @@ describe(`soundslice-data-api`, () => {
       const actual = Object.keys(apiClient).sort();
 
       const expected = [
+        `changeRecording`,
         `createFolder`,
         `createRecording`,
         `createSlice`,

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -39,6 +39,7 @@ describe(`soundslice-data-api`, () => {
         `moveSliceToFolder`,
         `putRecordingSyncpoints`,
         `renameFolder`,
+        `reorderSliceRecordings`,
         `uploadFile`,
       ];
 


### PR DESCRIPTION
## Description:

This PR adds two new methods.

#### `reorderSliceRecordings(paramsObj)`

- Reorder a slice's recordings.
- Sets the order of the recordings in the slice with a given `scorehash`.
- Soundslice documentation: ["Reorder slice’s recordings"](https://www.soundslice.com/help/data-api/#reorderrecordings)

```javascript
apiClient.reorderSliceRecordings({
  // The slice whose recordings you'd like to reorder.
  scorehash: 'abcde',
  // An array of recording IDs in your requested order.
  // **OR** a string of recording IDs separated by commas.
  //
  // The first recording ID is the top-most recording in the Soundslice UI, and so forth.
  // The last recording ID is the default.
  // Every recording in the slice must be included in this data.
  order: [222226, 222227, 222225],
  // Optionally, pass a comma-delimited string:
  // order: '222226,222227,222225'
})
```

#### `changeRecording(paramsObj)`

- Changes data for the recording with ID `recordingId`.
- It's possible change a recording's `name`, and/or `source_data`, and/or `hls_url`.
- Makes a POST request with the given parameters.
- Other than `recordingId`, all params are optional.
- If you don’t want to change a particular value, simply don't send its key with the request.
- Soundslice documentation: ["Change recording"](https://www.soundslice.com/help/data-api/#changerecording)

```javascript
apiClient.changeRecording({
  // Required
  recordingId: 123456,
  // The attribute of the recording that you'd like to change.
  name: 'Changed Recording Name',
  // Optionally, 'source_data' can be changed if `source` is 3 or 8.
  // Optionally, 'hls_url' can be changed if `source` is 3.
})
```

Closes https://github.com/ericcarraway/soundslice-data-api/issues/11